### PR TITLE
Adding onReadyStateChange callback to setVariables

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -97,8 +97,31 @@ declare module 'react-relay' {
     renderFailure?(error: Error, retry: Function): JSX.Element
   }
 
+  type ReadyStateEvent = 
+    'ABORT' |
+    'CACHE_RESTORED_REQUIRED' |
+    'CACHE_RESTORE_FAILED' |
+    'CACHE_RESTORE_START' |
+    'NETWORK_QUERY_ERROR' |
+    'NETWORK_QUERY_RECEIVED_ALL' |
+    'NETWORK_QUERY_RECEIVED_REQUIRED' |
+    'NETWORK_QUERY_START' |
+    'STORE_FOUND_ALL' |
+    'STORE_FOUND_REQUIRED';
+
+  interface OnReadyStateChange {
+    (readyState: {
+      ready: boolean,
+      done: boolean,
+      stale: boolean,
+      error?: Error,
+      events: Array<ReadyStateEvent>,
+      aborted: boolean
+    }): void
+  }
+
   interface RelayProp {
     variables: any
-    setVariables(variables: Object)
+    setVariables(variables: Object, onReadyStateChange?: OnReadyStateChange): void
   }
 }


### PR DESCRIPTION
`this.props.relay.setVariables` takes an optional callback that's not currently represented in the types. Just adding that.

See this answer on StackOverflow for a high-level overview:
http://stackoverflow.com/questions/35471836/loading-indicator-after-this-props-relay-setvariables-triggered-fetch

And the docs have more detailed information about what the callback provides:
https://facebook.github.io/relay/docs/guides-ready-state.html